### PR TITLE
Write jcmd style thread dump as a log body

### DIFF
--- a/control/src/main/java/com/splunk/opamp/remotecontrol/BigDumper.java
+++ b/control/src/main/java/com/splunk/opamp/remotecontrol/BigDumper.java
@@ -16,6 +16,7 @@
 
 package com.splunk.opamp.remotecontrol;
 
+import io.opentelemetry.api.logs.Logger;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
@@ -26,8 +27,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.logging.Level;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
 
 public class BigDumper {
+
+  private static final String DIAGNOSTIC_COMMAND_MBEAN =
+      "com.sun.management:type=DiagnosticCommand";
 
   private static final java.util.logging.Logger logger =
       java.util.logging.Logger.getLogger(BigDumper.class.getName());
@@ -35,10 +41,12 @@ public class BigDumper {
   private final ThreadMXBean threadMXBean;
   private final BiConsumer<String, ThreadInfo[]> threadDumpExporter;
   private final Object lock = new Object();
+  private final Logger threadDumpLogger;
   private ScheduledExecutorService executorService = null;
   private boolean dumping;
 
-  public BigDumper(BiConsumer<String, ThreadInfo[]> threadDumpExporter) {
+  public BigDumper(BiConsumer<String, ThreadInfo[]> threadDumpExporter, Logger threadDumpLogger) {
+    this.threadDumpLogger = threadDumpLogger;
     this.threadMXBean = ManagementFactory.getThreadMXBean();
     this.threadDumpExporter = threadDumpExporter;
   }
@@ -111,5 +119,46 @@ public class BigDumper {
     logger.fine("Taking a thread dump");
     ThreadInfo[] threadInfos = threadMXBean.dumpAllThreads(true, true);
     threadDumpExporter.accept(jobId, threadInfos);
+
+    String fullThreadDump = getFullThreadDump();
+    if (fullThreadDump != null) {
+      threadDumpLogger
+          .logRecordBuilder()
+          .setAttribute("splunk.thread.dump", true)
+          .setAttribute("profiling.job.id", jobId)
+          .setBody(fullThreadDump)
+          .emit();
+    }
+  }
+
+  /** Gets the large jcmd style hotspot wad as a single string. */
+  private static String getFullThreadDump() {
+    try {
+      MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+      ObjectName diagnosticCommand = new ObjectName(DIAGNOSTIC_COMMAND_MBEAN);
+
+      // This is the in-process form of `jcmd <pid> Thread.print`. Using HotSpot's formatter
+      // preserves details that ThreadInfo does not expose, such as native thread ids, VM/GC
+      // threads, elapsed times, native addresses, and the JNI reference counts.
+      String threadDump =
+          (String)
+              mBeanServer.invoke(
+                  diagnosticCommand,
+                  "threadPrint",
+                  new Object[] {new String[0]},
+                  new String[] {String[].class.getName()});
+      return currentProcessId() + ":" + System.lineSeparator() + threadDump;
+      //      Files.write(DEBUG_THREAD_DUMP_PATH, output.getBytes(StandardCharsets.UTF_8));
+    } catch (Exception exception) {
+      // The DiagnosticCommand MBean is a HotSpot facility and may not exist on other JVMs.
+      logger.log(Level.WARNING, "Unable to obtain a HotSpot diagnostic thread dump", exception);
+    }
+    return null;
+  }
+
+  private static String currentProcessId() {
+    String runtimeName = ManagementFactory.getRuntimeMXBean().getName();
+    int hostSeparator = runtimeName.indexOf('@');
+    return hostSeparator < 0 ? runtimeName : runtimeName.substring(0, hostSeparator);
   }
 }

--- a/opamp/src/main/java/com/splunk/opentelemetry/opamp/OpampActivator.java
+++ b/opamp/src/main/java/com/splunk/opentelemetry/opamp/OpampActivator.java
@@ -80,7 +80,13 @@ public class OpampActivator implements AgentListener {
           new PprofLogDataExporter(
               loggerOfCommands, ProfilingDataType.CPU, InstrumentationSource.THREADDUMP);
       PprofThreadDumpExporter threadDumpExporter = new PprofThreadDumpExporter(logDataExporter);
-      commandDispatcher = new CommandDispatcherImpl(new BigDumper(threadDumpExporter::export));
+      io.opentelemetry.api.logs.Logger threadDumpLogger =
+          autoConfiguredOpenTelemetrySdk
+              .getOpenTelemetrySdk()
+              .getSdkLoggerProvider()
+              .get("splunk.thread.dump");
+      BigDumper bigDumper = new BigDumper(threadDumpExporter::export, threadDumpLogger);
+      commandDispatcher = new CommandDispatcherImpl(bigDumper);
     }
     ServerToAgentMessageHandler serverToAgentMessageHandler =
         new ServerToAgentMessageHandler(


### PR DESCRIPTION
An example of how we might generate the entire jcmd-style thread dump output as a log body.